### PR TITLE
lotteries.name カラムのサイズを255文字までにする

### DIFF
--- a/db/migrate/20150816051539_change_name_limit_of_lotteries.rb
+++ b/db/migrate/20150816051539_change_name_limit_of_lotteries.rb
@@ -1,0 +1,10 @@
+class ChangeNameLimitOfLotteries < ActiveRecord::Migration
+  def up
+    execute("UPDATE lotteries SET name = SUBSTR(name, 1, 255)")
+    change_column(:lotteries, :name, :string, limit: 255)
+  end
+
+  def down
+    change_column(:lotteries, :name, :string, limit: nil)
+  end
+end


### PR DESCRIPTION
最初のmigration時に `limit: 255` を付け忘れていたのでつけました。
