### PR TITLE
追加抽選できるようにする [closes #36]

### DIFF
--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -29,11 +29,6 @@ class Lottery < ActiveRecord::Base
   end
 
   def draw!
-    if drawn
-      errors.add(:base, I18n.t("errors.messages.already_drawed"))
-      raise ActiveRecord::RecordInvalid.new(self)
-    end
-
     winners = LotteryDrawer.draw(candidates, winners_count)
 
     Lottery.transaction do

--- a/app/views/lotteries/show.html.haml
+++ b/app/views/lotteries/show.html.haml
@@ -17,12 +17,11 @@
     .col-md-2.title= Lottery.human_attribute_name :drawn
     .col-md-10= t("terms.choices.drawn.#{@lottery.drawn? ? 'true' : 'false'}")
 
-- if @lottery.drawn
-  %p
-    = link_to t('terms.operations.presentation'), lottery_presentation_path(@lottery), class: 'btn btn-success'
-- else
-  %p
-    = link_to t('terms.operations.draw'), lottery_draw_path(@lottery), method: :patch, class: 'btn btn-primary'
+  %section
+    - if @lottery.drawn
+      = link_to t('terms.operations.presentation'), lottery_presentation_path(@lottery), class: 'btn btn-success'
+    - if !@lottery.drawn || @lottery.redrawable?
+      = link_to t("terms.operations.#{@lottery.drawn? ? "redraw" : "draw"}"), lottery_draw_path(@lottery), method: :patch, class: 'btn btn-primary'
 
 .items-wrapper
   .col-md-4

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,6 +49,7 @@ ja:
       index: 一覧
       new: 新規登録
       presentation: 抽選結果発表
+      redraw: 追加抽選する
       update: 更新
     choices:
       drawn:

--- a/config/locales/rails.ja.yml
+++ b/config/locales/rails.ja.yml
@@ -99,7 +99,6 @@ ja:
   errors:
     format: "%{attribute}%{message}"
     messages:
-      already_drawed: 既に抽選済みです。
       accepted: を受諾してください
       blank: を入力してください
       present: は入力しないでください

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -14,17 +14,5 @@ describe "Lottery" do
         end.to change { lottery.drawn }.from(false).to(true).and change { lottery.candidates.winners.count }.from(0).to(winners_count)
       end
     end
-
-    context "抽選済みのとき" do
-      let(:drawn) { true }
-
-      it "検証エラーとなる" do
-        expect do
-          lottery.draw
-        end.to_not change { lottery.drawn }.from(true)
-        expect(lottery.candidates.winners.count).to eq 0
-        expect(lottery.errors[:base].count).to eq 1
-      end
-    end
   end
 end


### PR DESCRIPTION
実施済みの抽選で、実際の当選者の数が設定の当選者数より少ない時に、再抽選できるようにした。

時間不足につきノースペック(・ω<)。
