### PR TITLE
抽選結果発表のブラッシュアップ

### DIFF
--- a/app/assets/javascripts/reveal_after_load.js
+++ b/app/assets/javascripts/reveal_after_load.js
@@ -1,5 +1,5 @@
 Reveal.initialize({
-  controls: true,
+  controls: false,
   progress: true,
   history: true,
   center: true,

--- a/app/assets/stylesheets/reveal_customized.css.sass
+++ b/app/assets/stylesheets/reveal_customized.css.sass
@@ -13,18 +13,5 @@
       color: #777777
     &.white
       color: #ffffff
-  .btn
-    border: 0px solid #495267
-    border-radius: 8px
-    font-size: 72px
-    font-family: arial, helvetica, sans-serif
-    padding: 16px 24px
-    text-decoration: none
-    display: inline-block
-    text-shadow: -1px -1px 0 rgba(0,0,0,0.3)
-    font-weight: bold
-    color: #FFFFFF
-    background-color: #99AAC9
-    background-image: linear-gradient(to bottom, #99AAC9, #3f4c6b)
   .fa-spinner
     color: #f0f0f0

--- a/app/assets/stylesheets/reveal_customized.css.sass
+++ b/app/assets/stylesheets/reveal_customized.css.sass
@@ -13,3 +13,18 @@
       color: #777777
     &.white
       color: #ffffff
+  .btn
+    border: 0px solid #495267
+    border-radius: 8px
+    font-size: 72px
+    font-family: arial, helvetica, sans-serif
+    padding: 16px 24px
+    text-decoration: none
+    display: inline-block
+    text-shadow: -1px -1px 0 rgba(0,0,0,0.3)
+    font-weight: bold
+    color: #FFFFFF
+    background-color: #99AAC9
+    background-image: linear-gradient(to bottom, #99AAC9, #3f4c6b)
+  .fa-spinner
+    color: #f0f0f0

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -50,7 +50,7 @@ class LotteriesController < ApplicationController
 
   def presentation
     @all_winners = @lottery.winners
-    @new_winners = flash[:drawed_now] ?  @lottery.last_winners : @all_winners
+    @new_winners = flash[:drawed_now] ? @lottery.last_winners : @all_winners
 
     render layout: "slideshow"
   end

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -49,7 +49,9 @@ class LotteriesController < ApplicationController
   end
 
   def presentation
-    @winners = @lottery.winners
+    @all_winners = @lottery.winners
+    @new_winners = flash[:drawed_now] ?  @lottery.last_winners : @all_winners
+
     render layout: "slideshow"
   end
 

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -40,6 +40,7 @@ class LotteriesController < ApplicationController
 
   def draw
     if @lottery.draw
+      flash[:drawed_now] = true
       redirect_to lottery_presentation_path(@lottery)
     else
       message = "#{I18n.t('messages.failed')}\n#{@lottery.errors.full_messages.join("\n")}"

--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -36,6 +36,11 @@ class Lottery < ActiveRecord::Base
     candidates.maximum(:lot_number)
   end
 
+  def last_winners
+    return [] unless drawn?
+    candidates.where(lot_number: last_lot_number)
+  end
+
   def draw!
     lacked_winners_count = winners_count - winners.count
     return if drawn && lacked_winners_count <= 0

--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -32,6 +32,10 @@ class Lottery < ActiveRecord::Base
     winners_count > winners.count
   end
 
+  def last_lot_number
+    candidates.maximum(:lot_number)
+  end
+
   def draw!
     lacked_winners_count = winners_count - winners.count
     return if drawn && lacked_winners_count <= 0
@@ -39,10 +43,11 @@ class Lottery < ActiveRecord::Base
     rest_candidates = candidates.where(winner: false)
 
     winners = LotteryDrawer.draw(rest_candidates, lacked_winners_count)
+    new_lot_number = last_lot_number.to_i + 1
 
     Lottery.transaction do
       winners.each do |winner|
-        winner.update!(winner: true)
+        winner.update!(winner: true, lot_number: new_lot_number)
       end
       update!(drawn: true) unless drawn
     end

--- a/app/views/layouts/slideshow.html.haml
+++ b/app/views/layouts/slideshow.html.haml
@@ -2,6 +2,7 @@
 %html{ lang: "ja" }
   %head
     %title= t('app.name')
+    = stylesheet_link_tag    'application', media: 'all'
     = stylesheet_link_tag    'reveal_customized'
     = javascript_include_tag 'reveal'
     = csrf_meta_tags

--- a/app/views/lotteries/presentation.html.haml
+++ b/app/views/lotteries/presentation.html.haml
@@ -1,12 +1,9 @@
 - slide_contents = YAML.load_file("#{Rails.root}/config/slide_contents.yml")["slide_contents"]
 - slide_indexs = (0...slide_contents.count).to_a.shuffle
-- redrawed = @lottery.last_lot_number > 1
 .reveal
   .slides
     - if flash[:drawed_now]
-      %section.center
-        %h1= link_to t("terms.operations.#{ redrawed ? "redraw" : "draw"}"), '#', class: 'btn navigate-right'
-      %section.center{ data: { autoslide: 4000 } }
+      %section.center{ data: { autoslide: 3000 } }
         %h1= fa_icon('spinner', class: 'fa-spin fa-3x fa-fw')
     %section.center
       %h1= t("terms.titles.presentation_of_target", target: @lottery.name)

--- a/app/views/lotteries/presentation.html.haml
+++ b/app/views/lotteries/presentation.html.haml
@@ -10,7 +10,7 @@
         %h1= fa_icon('spinner', class: 'fa-spin fa-3x fa-fw')
     %section.center
       %h1= t("terms.titles.presentation_of_target", target: @lottery.name)
-    - @winners.each do |winner|
+    - @new_winners.each do |winner|
       - slide = slide_contents[cycle(slide_indexs).to_i]
       - filename = slide["filename"]
       - message = slide["message"][@lottery.message_type].gsub("{{name}}", winner.name)
@@ -22,9 +22,9 @@
       %h2= t("terms.titles.congratulations")
       %table
         %tbody
-          - 0.step(@winners.count - 1, 2) do |index|
+          - 0.step(@all_winners.count - 1, 2) do |index|
             %tr
-              %td= "#{index + 1}. #{@winners[index].name}"
-              - if @winners[index + 1]
-                %td= "#{index + 2}. #{@winners[index + 1].try(:name)}"
+              %td= "#{index + 1}. #{@all_winners[index].name}"
+              - if @all_winners[index + 1]
+                %td= "#{index + 2}. #{@all_winners[index + 1].try(:name)}"
 

--- a/app/views/lotteries/presentation.html.haml
+++ b/app/views/lotteries/presentation.html.haml
@@ -3,6 +3,10 @@
 .reveal
   .slides
     %section.center
+      %h1= link_to t("terms.operations.#{@lottery.drawn? ? "redraw" : "draw"}"), '#', class: 'btn navigate-right'
+    %section.center{ data: { autoslide: 4000 } }
+      %h1= fa_icon('spinner', class: 'fa-spin fa-3x fa-fw')
+    %section.center
       %h1= t("terms.titles.presentation_of_target", target: @lottery.name)
     - @winners.each do |winner|
       - slide = slide_contents[cycle(slide_indexs).to_i]

--- a/app/views/lotteries/presentation.html.haml
+++ b/app/views/lotteries/presentation.html.haml
@@ -1,11 +1,13 @@
 - slide_contents = YAML.load_file("#{Rails.root}/config/slide_contents.yml")["slide_contents"]
 - slide_indexs = (0...slide_contents.count).to_a.shuffle
+- redrawed = @lottery.last_lot_number > 1
 .reveal
   .slides
-    %section.center
-      %h1= link_to t("terms.operations.#{@lottery.drawn? ? "redraw" : "draw"}"), '#', class: 'btn navigate-right'
-    %section.center{ data: { autoslide: 4000 } }
-      %h1= fa_icon('spinner', class: 'fa-spin fa-3x fa-fw')
+    - if flash[:drawed_now]
+      %section.center
+        %h1= link_to t("terms.operations.#{ redrawed ? "redraw" : "draw"}"), '#', class: 'btn navigate-right'
+      %section.center{ data: { autoslide: 4000 } }
+        %h1= fa_icon('spinner', class: 'fa-spin fa-3x fa-fw')
     %section.center
       %h1= t("terms.titles.presentation_of_target", target: @lottery.name)
     - @winners.each do |winner|

--- a/db/migrate/20160528095741_add_lot_number_to_candidates.rb
+++ b/db/migrate/20160528095741_add_lot_number_to_candidates.rb
@@ -1,0 +1,11 @@
+class AddLotNumberToCandidates < ActiveRecord::Migration[5.0]
+  def up
+    add_column :candidates, :lot_number, :integer
+    # 既存レコードはすべて追加抽選なく1回目で抽選されたことにしておく
+    execute("UPDATE candidates SET lot_number = 1 WHERE winner = TRUE;")
+  end
+
+  def down
+    remove_column :candidates, :lot_number, :integer
+  end
+end


### PR DESCRIPTION
- 抽選/追加抽選直後はspinnerを出して抽選中の雰囲気を出した
- 追加抽選直後は、追加当選者のみ抽選結果発表に出るようにした
  - 最後の当選者のリストは全員のまま
